### PR TITLE
map icons display equipment name

### DIFF
--- a/MedicalTrackingApp/derby.log
+++ b/MedicalTrackingApp/derby.log
@@ -1,11 +1,11 @@
 ----------------------------------------------------------------
-Fri Feb 04 17:07:00 EST 2022:
-Booting Derby version The Apache Software Foundation - Apache Derby - 10.14.2.0 - (1828579): instance a816c00e-017e-c6c6-bc49-0000075af5e8 
-on database directory memory:C:\Users\aberf\Documents\GitHub\MedicalTracking\MedicalTrackingApp\ESpikeB with class loader jdk.internal.loader.ClassLoaders$AppClassLoader@725bef66 
-Loaded from file:/C:/Users/aberf/.gradle/caches/modules-2/files-2.1/org.apache.derby/derby/10.14.2.0/7efad40ef52fbb1f08142f07a83b42d29e47d8ce/derby-10.14.2.0.jar
+Sat Feb 05 22:14:08 EST 2022:
+Booting Derby version The Apache Software Foundation - Apache Derby - 10.14.2.0 - (1828579): instance a816c00e-017e-cd06-47f7-000026d1da00 
+on database directory memory:C:\Users\josem\Documents\schoolWork\CS3733\TempDBThingthatOff\MedicalTracking\MedicalTrackingApp\ESpikeB with class loader jdk.internal.loader.ClassLoaders$AppClassLoader@725bef66 
+Loaded from file:/C:/Users/josem/.gradle/caches/modules-2/files-2.1/org.apache.derby/derby/10.14.2.0/7efad40ef52fbb1f08142f07a83b42d29e47d8ce/derby-10.14.2.0.jar
 java.vendor=Microsoft
-java.runtime.version=11.0.12+7
-user.dir=C:\Users\aberf\Documents\GitHub\MedicalTracking\MedicalTrackingApp
+java.runtime.version=11.0.13+8-LTS
+user.dir=C:\Users\josem\Documents\schoolWork\CS3733\TempDBThingthatOff\MedicalTracking\MedicalTrackingApp
 os.name=Windows 10
 os.arch=amd64
 os.version=10.0

--- a/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/PannableView.java
+++ b/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/PannableView.java
@@ -116,7 +116,8 @@ public class PannableView {
   }
 
   // Adds icon on click
-  // TODO make this meaningful. Right now it just makes a button with whatever icon you tell it to make
+  // TODO make this meaningful. Right now it just makes a button with whatever icon you tell it to
+  // make
   private void addMapIcon(double xCoordinate, double yCoordinate, String type) {
     Image iconImage = new Image(App.class.getResource("images/Icons/" + type).toString());
     ImageView iconGraphic = new ImageView(iconImage);
@@ -264,7 +265,7 @@ public class PannableView {
         new MapIcon(
             (double) equip.getLocationNode().getX(),
             (double) equip.getLocationNode().getY(),
-            equip.getLocationNode().getLongName(),
+            equip.getName(),
             getImageViewFromEquipmentType(equip.getType()));
     mapIcons.add(retval);
     updateLayoutChildren();


### PR DESCRIPTION
#123 
Icons displayed the name of the location where the equipment was instead of the name of the equipment itself. Changed that in PannableViews convertLocationToMapIcon().