### PR TITLE
Made some changes to the cleanDBTables function

### DIFF
--- a/MedicalTrackingApp/src/main/java/edu/wpi/teame/db/DBManager.java
+++ b/MedicalTrackingApp/src/main/java/edu/wpi/teame/db/DBManager.java
@@ -468,8 +468,30 @@ public final class DBManager {
   }
 
   private void cleanDBTables() throws SQLException {
-    for (DataBaseObjectType dbTable : DataBaseObjectType.values()) {
-      stmt.executeUpdate("DELETE " + dbTable.toString());
+    DataBaseObjectType[] deleteOrder =
+        new DataBaseObjectType[] {
+          DataBaseObjectType.AudioVisualSR,
+          DataBaseObjectType.ComputerSR,
+          DataBaseObjectType.FoodDeliverySR,
+          DataBaseObjectType.GiftAndFloralSR,
+          DataBaseObjectType.InternalPatientTransferSR,
+          DataBaseObjectType.ExternalPatientSR,
+          DataBaseObjectType.LanguageInterpreterSR,
+          DataBaseObjectType.LaundrySR,
+          DataBaseObjectType.ReligiousSR,
+          DataBaseObjectType.SecuritySR,
+          DataBaseObjectType.MedicalEquipmentSR,
+          DataBaseObjectType.MedicineDeliverySR,
+          DataBaseObjectType.FacilitiesMaintenanceSR,
+          DataBaseObjectType.SanitationSR,
+          DataBaseObjectType.Patient,
+          DataBaseObjectType.Employee,
+          DataBaseObjectType.Equipment,
+          DataBaseObjectType.Location
+        };
+
+    for (DataBaseObjectType dbTable : deleteOrder) {
+      stmt.executeUpdate("DELETE FROM " + dbTable.toTableName());
     }
   }
 

--- a/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/Equipment.java
+++ b/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/Equipment.java
@@ -41,7 +41,6 @@ public class Equipment implements ISQLSerializable {
     this.name = resultSet.getString("name");
     this.hasPatient = resultSet.getBoolean("hasPatient");
     this.isClean = resultSet.getBoolean("isClean");
-    System.out.println(location);
   }
 
   public int getId() {

--- a/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/enums/DataBaseObjectType.java
+++ b/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/enums/DataBaseObjectType.java
@@ -20,7 +20,6 @@ public enum DataBaseObjectType {
   MedicineDeliverySR,
   FacilitiesMaintenanceSR,
   SanitationSR,
-
   Location,
   Equipment,
   Patient,
@@ -63,6 +62,48 @@ public enum DataBaseObjectType {
         return "Location";
       case Equipment:
         return "Equipment";
+    }
+    return null;
+  }
+
+  public String toTableName() {
+    switch (this) {
+      case AudioVisualSR:
+        return "AudioVisualSR";
+      case ComputerSR:
+        return "ComputerSR";
+      case FoodDeliverySR:
+        return "FoodDeliverySR";
+      case GiftAndFloralSR:
+        return "GiftAndFloralSR";
+      case ExternalPatientSR:
+        return "ExternalPatientSR";
+      case LanguageInterpreterSR:
+        return "LanguageInterpreterSR";
+      case InternalPatientTransferSR:
+        return "InternalPatientTransferSR";
+      case LaundrySR:
+        return "LaundrySR";
+      case SecuritySR:
+        return "SecuritySR";
+      case ReligiousSR:
+        return "ReligiousSR";
+      case SanitationSR:
+        return "SanitationSR";
+      case MedicalEquipmentSR:
+        return "MedicalEquipmentSR";
+      case MedicineDeliverySR:
+        return "MedicineDeliverySR";
+      case FacilitiesMaintenanceSR:
+        return "FacilitiesMaintenanceSR";
+      case Employee:
+        return "Employee";
+      case Location:
+        return "Location";
+      case Equipment:
+        return "Equipment";
+      case Patient:
+        return "Patient";
     }
     return null;
   }

--- a/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/serviceRequests/ServiceRequest.java
+++ b/MedicalTrackingApp/src/main/java/edu/wpi/teame/model/serviceRequests/ServiceRequest.java
@@ -223,6 +223,34 @@ public class ServiceRequest implements ISQLSerializable {
   }
 
   public String toString() {
-    return this.dbType + " id is " + id;
+    return "id = "
+        + id
+        + "locationID = "
+        + location.getId()
+        + ", "
+        + "assigneeID = "
+        + assignee.getId()
+        + ", "
+        + "openDate = '"
+        + dateToSQLString(openDate)
+        + "', "
+        + "closeDate = "
+        + closeDate.toString()
+        + ", "
+        + "status = "
+        + status.ordinal()
+        + ", "
+        + "title = '"
+        + title
+        + "', "
+        + "additionalInfo = '"
+        + additionalInfo
+        + "', "
+        + "priority = "
+        + priority.ordinal()
+        + ", "
+        + "requestDate = '"
+        + dateToSQLString(requestDate)
+        + "'";
   }
 }

--- a/MedicalTrackingApp/src/main/java/edu/wpi/teame/view/controllers/SettingsPageController.java
+++ b/MedicalTrackingApp/src/main/java/edu/wpi/teame/view/controllers/SettingsPageController.java
@@ -123,7 +123,7 @@ public class SettingsPageController implements Initializable {
       accessibilityComboBox.setItems(
           FXCollections.observableArrayList(new String[] {"None", "Color Blind Mode"}));
 
-      dbSwitchComboBox.setValue(properties.getProperty("dbConnection"));
+      // dbSwitchComboBox.setValue(properties.getProperty("dbConnection"));
       languageComboBox.setValue(properties.getProperty("language"));
       colorComboBox.setValue(properties.getProperty("color"));
       accessibilityComboBox.setValue(properties.getProperty("accessibility"));


### PR DESCRIPTION
Before, the cleanDBTables function went through and deleted the tables in the order of whats in the DataBaseObjectType enum. The problem with this is that it'll delete the values in the location table before the equipment table. Equipment has location as a foreign key so that threw some sql errors. I just made a array of DBObjectTypes with location below everything else. The delete sql line was just "DELETE" and the toString value of the enum which is not the name of the table. For example, ComputerSR.toString is "Computer Service Request" and the table name is ComputerSR. I assumed that toString value is used somewhere else so I made a new function that'll return the table name. Also, the sql line should have been "DELETE FROM" so i just changed that.